### PR TITLE
Changes th eigenvector extraction of R_x

### DIFF
--- a/test.m
+++ b/test.m
@@ -30,7 +30,7 @@ output = zeros(T, F);    %beamforming outputs
 
 %% Get steering vectors d using eigvalue composition 
 for f= 1:F
-    [V, D] = eig(squeeze(Rx(:, :, f)));
+    [V, ~, ~] = svd(Rx(:,:,f));
     d(:, f) = V(:, 1);
 end
 %% Do MVDR beamforming


### PR DESCRIPTION
In Matlab, eig() function does not always return eigenvalues in sorted order, so we should sort it as https://www.mathworks.com/help/matlab/ref/eig.html “Sorted Eigenvalues and Eigenvectors” part do, or we can just use svd() function, which always returns eigenvalues in descending order(as https://www.mathworks.com/help/matlab/ref/double.svd.html  says) and then do the subsequent procedures.